### PR TITLE
Add concat

### DIFF
--- a/lib/travis/conditions/v1/eval.rb
+++ b/lib/travis/conditions/v1/eval.rb
@@ -9,7 +9,8 @@ module Travis
         private
 
           def evl(expr)
-            cast(send(*expr))
+            expr = send(*expr) if expr.is_a?(Array)
+            cast(expr)
           end
 
           def not(lft)
@@ -61,8 +62,8 @@ module Travis
             str
           end
 
-          def reg(str)
-            Regexp.new(str)
+          def reg(expr)
+            Regexp.new(evl(expr))
           end
 
           def var(name)

--- a/lib/travis/conditions/v1/eval.rb
+++ b/lib/travis/conditions/v1/eval.rb
@@ -77,6 +77,10 @@ module Travis
             data.env(key)
           end
 
+          def concat(*args)
+            args.inject('') { |str, arg| str + arg.to_s }
+          end
+
           def present(value)
             value.respond_to?(:empty?) && !value.empty?
           end

--- a/lib/travis/conditions/v1/parser.rb
+++ b/lib/travis/conditions/v1/parser.rb
@@ -18,7 +18,7 @@ require 'travis/conditions/v1/helper'
 #      | 'tag'
 #      | 'commit_message';
 #
-# func = 'env';
+# func = 'env' || 'concat';
 # pred = 'present' | 'blank';
 #
 # eq   = '=' | '==' | '!=';
@@ -57,7 +57,7 @@ module Travis
                  branch|head_branch|tag|commit_message/ix
 
         PRED  = /present|blank|true|false/i
-        FUNC  = /env/i
+        FUNC  = /env|concat/i
         IN    = /in|not in/i
         IS    = /is not|is/i
         EQ    = /==|=/

--- a/lib/travis/conditions/v1/parser.rb
+++ b/lib/travis/conditions/v1/parser.rb
@@ -139,7 +139,7 @@ module Travis
           nil
         end
 
-        BOUND = /[\s=)|]/
+        BOUND = /[\s,=)|]/
 
         def boundary?
           peek(1) =~ BOUND || str.eos?

--- a/spec/v1/eval_spec.rb
+++ b/spec/v1/eval_spec.rb
@@ -157,6 +157,16 @@ describe Travis::Conditions::V1, 'eval' do
       let(:str) { 'env(foo) =~ ^bar.*$' }
       it { should be false }
     end
+
+    context do
+      let(:str) { 'env(foo) =~ env(foo)' }
+      it { should be true }
+    end
+
+    context do
+      let(:str) { 'env(foo) =~ concat("^", env(foo), "$")' }
+      it { should be true }
+    end
   end
 
   describe 'in' do

--- a/spec/v1/eval_spec.rb
+++ b/spec/v1/eval_spec.rb
@@ -67,6 +67,11 @@ describe Travis::Conditions::V1, 'eval' do
     end
 
     context do
+      let(:str) { 'concat(foo, bar) = foobar' }
+      it { should be true }
+    end
+
+    context do
       let(:tag) { '0.0.1' }
       let(:str) { 'tag =~ /^(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([\w.-]+))?(?:\+([\w.-]+))?$ AND type IN (push, api)/' }
       it { should be false }

--- a/spec/v1/eval_spec.rb
+++ b/spec/v1/eval_spec.rb
@@ -67,7 +67,12 @@ describe Travis::Conditions::V1, 'eval' do
     end
 
     context do
-      let(:str) { 'concat(foo, bar) = foobar' }
+      let(:str) { 'concat(foo, -, bar) = foo-bar' }
+      it { should be true }
+    end
+
+    context do
+      let(:str) { 'concat(branch, -, env(foo), -, env(bar)) = master-foo-false' }
       it { should be true }
     end
 

--- a/spec/v1/eval_spec.rb
+++ b/spec/v1/eval_spec.rb
@@ -215,6 +215,21 @@ describe Travis::Conditions::V1, 'eval' do
     end
 
     context do
+      let(:str) { 'env(foo) IS present' }
+      it { should be true }
+    end
+
+    context do
+      let(:str) { 'env(bar) IS present' }
+      it { should be false }
+    end
+
+    context do
+      let(:str) { 'env(baz) IS present' }
+      it { should be false }
+    end
+
+    context do
       let(:str) { 'branch IS blank' }
       it { should be false }
     end
@@ -225,12 +240,17 @@ describe Travis::Conditions::V1, 'eval' do
     end
 
     context do
-      let(:str) { 'env(foo) IS present' }
-      it { should be true }
+      let(:str) { 'env(foo) IS blank' }
+      it { should be false }
     end
 
     context do
       let(:str) { 'env(bar) IS blank' }
+      it { should be true }
+    end
+
+    context do
+      let(:str) { 'env(baz) IS blank' }
       it { should be true }
     end
   end

--- a/spec/v1/parser/call_spec.rb
+++ b/spec/v1/parser/call_spec.rb
@@ -58,6 +58,10 @@ describe Travis::Conditions::V1::Parser, 'call' do
     should eq [:call, :concat, [[:val, 'foo'], [:call, :env, [[:val, 'bar']]]]]
   end
 
+  it 'concat(branch, foo)' do
+    should eq [:call, :concat, [[:var, :branch], [:val, 'foo']]]
+  end
+
   it 'bar()' do
     should be_nil
   end

--- a/spec/v1/parser/call_spec.rb
+++ b/spec/v1/parser/call_spec.rb
@@ -42,6 +42,22 @@ describe Travis::Conditions::V1::Parser, 'call' do
     should eq [:call, :env, [[:val, 'foo'], [:val, 'bar']]]
   end
 
+  it 'concat()' do
+    should eq [:call, :concat, []]
+  end
+
+  it 'concat(foo)' do
+    should eq [:call, :concat, [[:val, 'foo']]]
+  end
+
+  it 'concat(foo, bar)' do
+    should eq [:call, :concat, [[:val, 'foo'], [:val, 'bar']]]
+  end
+
+  it 'concat(foo, env(bar))' do
+    should eq [:call, :concat, [[:val, 'foo'], [:call, :env, [[:val, 'bar']]]]]
+  end
+
   it 'bar()' do
     should be_nil
   end

--- a/spec/v1/parser/term_spec.rb
+++ b/spec/v1/parser/term_spec.rb
@@ -50,6 +50,10 @@ describe Travis::Conditions::V1::Parser, 'term' do
     should eq [:match, [:var, :tag], [:reg, [:call, :env, [[:val, 'foo']]]]]
   end
 
+  it 'tag =~ concat(^foo-, env(foo))' do
+    should eq [:match, [:var, :tag], [:reg, [:call, :concat, [[:val, "^foo-"], [:call, :env, [[:val, 'foo']]]]]]]
+  end
+
   it 'type IN (foo)' do
     should eq [:in, [:var, :type], [[:val, 'foo']]]
   end


### PR DESCRIPTION
As per https://github.com/travis-ci/travis-conditions/pull/1#issuecomment-397258759

The intention with this is:

```
env: SERVICE=some-service
if: branch =~ concat(^srv-,env(SERVICE),-) # equivalent to branch =~ ^srv-some-service-
```

I think this is a valid usecase, so I'm proposing to add this.