### PR TITLE
Fix regular expression parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,28 @@ See [this file](https://github.com/travis-ci/travis-conditions/blob/master/lib/t
 ## CLI
 
 With the gem installed you can use the command `travis-conditions` in order to
-test your conditions locally. For example:
+test your conditions locally.
+
+### parse
+
+Check the syntax of a condition by inspecting the resulting abstract syntax
+tree.
 
 ```
-$ travis-conditions "branch = foo" --data '{"branch": "foo"}'
+$ travis-conditions eval "branch = foo"
+[:eq, [:var, :branch], [:val, "foo"]]
+
+```
+
+### eval
+
+Check conditions against a given data hash.
+
+```
+$ travis-conditions eval "branch = foo" --data '{"branch": "foo"}'
 true
 
-$ echo '{"branch": "foo"}' | travis-conditions "branch = foo"
+$ echo '{"branch": "foo"}' | travis-conditions eval "branch = foo"
 true
 ```
 
@@ -30,9 +45,9 @@ The given `data` hash can include known attributes (such as branch, tag, repo)
 and an `env` key that can either hold a hash, or an array of strings:
 
 ```
-$ travis-conditions "env(foo) = bar" --data '{"env": {"foo": "bar"}}'
+$ travis-conditions eval "env(foo) = bar" --data '{"env": {"foo": "bar"}}'
 true
-$ travis-conditions "env(foo) = bar" --data '{"env": ["foo=bar"]}'
+$ travis-conditions eval "env(foo) = bar" --data '{"env": ["foo=bar"]}'
 true
 ```
 

--- a/bin/travis-conditions
+++ b/bin/travis-conditions
@@ -4,20 +4,41 @@ $: << 'lib'
 
 require 'json'
 require 'optparse'
+require 'pp'
 require 'travis/conditions'
 
 def help
-  abort <<~help
-    Usage:
-      travis-conditions "branch = master" --data '{"branch": "master"}'
-      travis-conditions echo '{"branch": "master"}' | travis-conditions "branch = master"
+  abort <<~str
+    SYNOPSIS:
 
-    The given data JSON hash can include known attributes (such as branch, tag,
-    repo) and an "env" key that can either hold a hash, or an array of strings:
+      travis-conditions <command>
 
-      {"env": {"foo": "bar"}}
-      {"env": ["foo=bar"]}
-  help
+    COMMANDS:
+
+      parse
+
+        Validate the syntax of a condition, inspect the resulting abstract
+        syntax tree.
+
+        E.g.:
+
+          travis-conditions parse "branch = master"
+
+      eval
+
+        Validate the behavior of a condition, given an input data hash.
+
+        E.g.:
+
+          travis-conditions eval "branch = master" --data '{"branch": "master"}'
+          echo '{"branch": "master"}' | eval travis-conditions "branch = master"
+
+        The given data JSON hash can include known attributes (such as branch, tag,
+        repo) and an "env" key that can either hold a hash, or an array of strings:
+
+          {"env": {"foo": "bar"}}
+          {"env": ["foo=bar"]}
+  str
 end
 
 data = $stdin.read unless $stdin.tty?
@@ -28,7 +49,19 @@ ARGV.options do |opts|
   opts.parse!
 end
 
-cond = ARGV.shift
-abort help unless cond && data
+cmd = ARGV.shift
+abort help unless cmd
 
-p Travis::Conditions.eval(cond, JSON.parse(data), version: :v1)
+cond = ARGV.shift
+abort help unless cond && (cmd == 'parse' || data)
+
+begin
+  case cmd
+  when 'parse'
+    pp Travis::Conditions.parse(cond, version: :v1)
+  when 'eval'
+    p Travis::Conditions.eval(cond, JSON.parse(data), version: :v1)
+  end
+rescue Travis::Conditions::ParseError => e
+  abort e.message
+end

--- a/lib/travis/conditions/v1.rb
+++ b/lib/travis/conditions/v1.rb
@@ -1,6 +1,7 @@
 require 'travis/conditions/v1/data'
 require 'travis/conditions/v1/eval'
 require 'travis/conditions/v1/parser'
+require 'travis/conditions/v1/regex'
 
 module Travis
   module Conditions

--- a/lib/travis/conditions/v1/parser.rb
+++ b/lib/travis/conditions/v1/parser.rb
@@ -66,7 +66,6 @@ module Travis
         NRE   = /!~/
         COMMA = /,/
         WORD  = /[^\s\(\)"',=!]+/
-        REGEX = %r(/.+/|\S*[^\s\)]+)
         CONT  = /\\\s*[\n\r]/
 
         OP = {
@@ -84,7 +83,7 @@ module Travis
           shell_str:   'Strings cannot start with a dollar (shell code does not work). This can be bypassed by quoting the string.'
         }
 
-        def_delegators :str, :scan, :skip, :string, :pos, :peek
+        def_delegators :str, :rest, :scan, :skip, :string, :pos, :peek
         attr_reader :str
 
         def initialize(str)
@@ -118,8 +117,9 @@ module Travis
         def regex
           val = call
           return [:reg, val] if val
-          reg = space { scan(REGEX) }
-          [:reg, reg.gsub(/^\/|\/$/, '')] or err('an operand')
+          return unless reg = space { Regex.new(rest).scan }
+          str.pos = str.pos + reg.size
+          [:reg, reg.gsub(%r(^/|/$), '')] # or err('an operand')
         end
 
         def eq

--- a/lib/travis/conditions/v1/regex.rb
+++ b/lib/travis/conditions/v1/regex.rb
@@ -1,0 +1,54 @@
+require 'strscan'
+require 'forwardable'
+
+module Travis
+  module Conditions
+    module V1
+      class Regex
+        REGEX = %r(\S*[^\s\)]+)
+        DELIM = '/'
+        ESC   = '\\'
+
+        extend Forwardable
+
+        def_delegators :str, :check, :eos?, :getch, :peek, :pos, :scan, :skip, :string
+        attr_reader :str
+
+        def initialize(str)
+          @str = StringScanner.new(str.to_s.strip)
+          @esc = false
+        end
+
+        def scan
+          word || regex
+        end
+
+        def word
+          return if peek(1) == DELIM
+          str.scan(REGEX)
+        end
+
+        def regex
+          return unless peek(1) == DELIM && reg = getch
+          char = nil
+          reg << char while (char = read) && char != :eos
+          reg << DELIM if char == :eos
+          reg unless reg.empty?
+        end
+
+        def read
+          char = peek(1)
+          if char == DELIM && !@esc
+            :eos
+          elsif char == ESC
+            @esc = true
+            getch
+          else
+            @esc = false
+            getch
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/v1/data_spec.rb
+++ b/spec/v1/data_spec.rb
@@ -59,6 +59,7 @@ describe Travis::Conditions::V1::Data do
     describe 'with a string and a secure env var' do
       let(:env) { ["FOO=foo BAR=bar", { secure: '12345' }] }
       it { expect(subject.env(:FOO)).to eq 'foo' }
+      it { expect(subject.env(:BAR)).to eq 'bar' }
     end
   end
 

--- a/spec/v1/parser/regex_spec.rb
+++ b/spec/v1/parser/regex_spec.rb
@@ -1,12 +1,47 @@
 describe Travis::Conditions::V1::Parser, 'regex' do
   let(:str) { |e| e.description }
-  let(:subject) { described_class.new(str).regex }
+  let(:subject) { described_class.new(str).parse }
 
-  it '^.*-bar$' do
-    should eq [:reg, '^.*-bar$']
+  it 'branch =~ ^.*-foo$' do
+    should eq [:match, [:var, :branch], [:reg, '^.*-foo$']]
   end
 
-  it '/^.* bar$/' do
-    should eq [:reg, '^.* bar$']
+  it 'branch =~ /^.* foo$/' do
+    should eq [:match, [:var, :branch], [:reg, '^.* foo$']]
+  end
+
+  it 'branch =~ /foo/ OR tag =~ /^foo$/' do
+    should eq [:or,
+      [:match, [:var, :branch], [:reg, 'foo']],
+      [:match, [:var, :tag], [:reg, '^foo$']]
+    ]
+  end
+
+  it 'branch =~ /foo/ OR (tag =~ /^foo$/)' do
+    should eq [:or,
+      [:match, [:var, :branch], [:reg, 'foo']],
+      [:match, [:var, :tag], [:reg, '^foo$']]
+    ]
+  end
+end
+
+describe Travis::Conditions::V1::Regex do
+  let(:str) { |e| e.description }
+  let(:subject) { described_class.new(str).scan }
+
+  it '^.*-foo$' do
+    should eq '^.*-foo$'
+  end
+
+  it '/^.* foo$/' do
+    should eq '/^.* foo$/'
+  end
+
+  it '/^(develop|master|release\/.*)$/' do
+    should eq '/^(develop|master|release\/.*)$/'
+  end
+
+  it '/^(develop|master|release\/.*|feature\/.*)$/' do
+    should eq '/^(develop|master|release\/.*|feature\/.*)$/'
   end
 end

--- a/spec/v1/user_spec.rb
+++ b/spec/v1/user_spec.rb
@@ -65,7 +65,7 @@ describe Travis::Conditions::V1, 'real conditions' do
     fork = false
     not tag =~ ^autobuild
     tag =~ ''
-    tag =~ /(^version_code\/)|(^$)/
+    tag =~ /(^version_code\\/)|(^$)/
     tag =~ /^$|\s+/
     tag =~ [0-9]+\.[0-9]+\.[0-9]+
     tag =~ ^\d+(\.\d+)+(-.*)?


### PR DESCRIPTION
Should fix https://github.com/travis-ci/travis-conditions/issues/10

The previous logic would fail with multiple regexes as the parsing expression was too greedy. Simply making it ungreedy would then fail regular expressions that have a nested, escaped slash. Introducing a small Scanner class fixes this.

Also adds `parse` and `eval` subcommands to the binary `travis-conditions` (with `eval` being the only behaviour previously), so we can use it to inspect the resulting AST.