### PR TITLE
Fix env_vars usage for jc-collection branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'travis-env_vars', git: 'https://github.com/travis-ci/travis-env_vars', ref: 'sf-env_vars'
+gem 'travis-env_vars', git: 'https://github.com/travis-ci/travis-env_vars', ref: 'jc-collection'
 gem 'parslet'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/travis-ci/travis-env_vars
-  revision: 6ed4b4c27f5f9a57f4aa9f0ae8e15a6dfaf7eeb6
-  ref: sf-env_vars
+  revision: f2c2f6bbc02927bf380afeb7a2d6a0a50f459aa0
+  ref: jc-collection
   specs:
-    travis-env_vars (0.1.0)
+    travis-env_vars (0.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -33,4 +33,4 @@ DEPENDENCIES
   travis-env_vars!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/travis/conditions/v1/data.rb
+++ b/lib/travis/conditions/v1/data.rb
@@ -55,7 +55,7 @@ module Travis
           end
 
           def parse(str)
-            vars = EnvVars::String.new(str).parse
+            vars = EnvVars.new(str).to_pairs
             vars.map { |lft, rgt| [lft, cast(unquote(rgt))] }
           rescue EnvVars::ParseError
             puts "[travis-conditions] Cannot normalize env var (#{str.inspect} given)"


### PR DESCRIPTION
Changes the way this lib uses travis-env_vars.

Reliant on https://github.com/travis-ci/travis-env_vars/pull/2 – don't merge until afterwards.