### PR TITLE
dequote quoted env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
-sudo: false
+language: ruby
+ruby: 2.6.2
 cache: bundler
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'sh_vars'
+gem 'parslet'
+
+gemspec
 
 group :test do
   gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'sh_vars'
-gem 'parslet'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+PATH
+  remote: .
+  specs:
+    travis-conditions (1.0.9)
+      parslet (~> 1.8.2)
+      sh_vars (~> 1.0.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,6 +32,7 @@ DEPENDENCIES
   parslet
   rspec
   sh_vars
+  travis-conditions!
 
 BUNDLED WITH
    2.0.2

--- a/lib/travis/conditions/v1/data.rb
+++ b/lib/travis/conditions/v1/data.rb
@@ -13,7 +13,9 @@ module Travis
         end
 
         def env(key)
-          data.fetch(:env, {})[key.to_sym]
+          value = data.fetch(:env, {})[key.to_sym]
+          value = value.gsub(/^(["'])(.*)\1$/, '\2') if value.respond_to?(:gsub)
+          value
         end
 
         private

--- a/spec/v1/conditions_spec.rb
+++ b/spec/v1/conditions_spec.rb
@@ -47,4 +47,11 @@ describe Travis::Conditions::V1, 'real conditions' do
     let(:cond) { 'commit_message !~ concat("[skip", env(TRAVIS_JOB_NAME), "]")' }
     it { expect { described_class.parse(cond) }.to_not raise_error }
   end
+
+  describe 'quoted env var' do
+    let(:cond) { 'branch = env(FOO)' }
+    let(:data) { { branch: 'foo', env: [FOO: '"foo"'] } }
+    subject { described_class.eval(cond, data) }
+    it { should be true }
+  end
 end

--- a/spec/v1/data_spec.rb
+++ b/spec/v1/data_spec.rb
@@ -71,6 +71,36 @@ describe Travis::Conditions::V1::Data do
     end
   end
 
+  describe 'given a double quoted string' do
+    let(:env) { [FOO: '"foo"'] }
+    it { expect(subject.env(:FOO)).to eq 'foo' }
+  end
+
+  describe 'given a single quoted string' do
+    let(:env) { [FOO: "'foo'"] }
+    it { expect(subject.env(:FOO)).to eq 'foo' }
+  end
+
+  describe 'given a string with an unbalanced double quote at the beginning' do
+    let(:env) { [FOO: '"foo'] }
+    it { expect(subject.env(:FOO)).to eq '"foo' }
+  end
+
+  describe 'given a string with an unbalanced double quote at the end' do
+    let(:env) { [FOO: 'foo"'] }
+    it { expect(subject.env(:FOO)).to eq 'foo"' }
+  end
+
+  describe 'given a string with an unbalanced single quote at the beginning' do
+    let(:env) { [FOO: "'foo"] }
+    it { expect(subject.env(:FOO)).to eq "'foo" }
+  end
+
+  describe 'given a string with an unbalanced single quote at the end' do
+    let(:env) { [FOO: "foo'"] }
+    it { expect(subject.env(:FOO)).to eq "foo'" }
+  end
+
   describe 'given a string without an = it raises an ArgumentError' do
     let(:env) { 'foo' }
     xit { expect { subject }.to raise_error Travis::Conditions::ArgumentError, 'Invalid env data ("foo" given)' }

--- a/travis-conditions.gemspec
+++ b/travis-conditions.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.executables << 'travis-conditions'
 
   s.add_dependency 'sh_vars', '~> 1.0.2'
+  s.add_dependency 'parslet', '~> 1.8.2'
 end


### PR DESCRIPTION
e.g. 

```
env:
- BRANCH="master"
```

would result in `[BRANCH: '"master"']`

i think it is safe enough to just dequote those strings for this purpose here.